### PR TITLE
adapt the scripts to the new amtoine-icons-git package

### DIFF
--- a/scripts/amtoine-battery
+++ b/scripts/amtoine-battery
@@ -27,7 +27,7 @@ eval set -- "$OPTIONS"
 [ -z "$BATTERY" ] && BATTERY="BAT0"
 [ -z "$LOW" ] && LOW=15
 [ -z "$HIGH" ] && HIGH=85
-[ -z "$ICONS" ] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[ -z "$ICONS" ] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [ -z "$DUNST_ID" ] && DUNST_ID=1
 
 # the location of the battery information files
@@ -87,6 +87,29 @@ _check_battery_state() {
 }
 
 
+_get_icon_name () {
+    # Get the icon name based on the status and the level.
+    #
+    # Args:
+    #   $1: the status of the battery.
+    #   $2: the level of the battery.
+    status="$1"
+    if [ "$status" == "Charging" ]; then
+        dir="charging"
+    else
+        dir="normal"
+    fi
+
+    level="$2"
+    name="$((level / 10))0"
+    if [ "$level" -ne 100 ]; then
+        name="0$name"
+    fi
+
+    echo "$dir/level-$name.png"
+}
+
+
 print_battery () {
     # Print the state of the battery in a notification.
     #
@@ -95,16 +118,10 @@ print_battery () {
     #   $2: the level of the battery.
     status="$1"
     level="$2"
-    if [ "$level" -lt "25" ]; then
-        icon="critical"
-    elif [ "$level" -lt "50" ]; then
-        icon="low"
-    elif [ "$level" -lt "75" ]; then
-        icon="normal"
-    else
-        icon="full"
-    fi
-    dunstify --urgency low "amtoine-battery" "$BATTERY is $status at $level" --icon="$ICONS/battery/$icon.png" --timeout 5000 --replace="$DUNST_ID"
+
+    icon=$(_get_icon_name "$status" "$level")
+
+    dunstify --urgency low "amtoine-battery" "$BATTERY is $status at $level" --icon="$ICONS/battery/$icon" --timeout 5000 --replace="$DUNST_ID"
 }
 
 
@@ -120,12 +137,8 @@ check_battery () {
 
     # throw a notification only if required.
     if [ -n "$state" ]; then
-        if [ "$state" = "low" ]; then
-            icon="$ICONS/battery/critical.png"
-        elif [ "$state" = "high" ]; then
-            icon="$ICONS/battery/full.png"
-        fi
-        dunstify --urgency critical "amtoine-battery" "$BATTERY is $state\n($status at $level%)" --icon="$icon" --replace="$DUNST_ID";
+        icon=$(_get_icon_name "$status" "$level")
+        dunstify --urgency critical "amtoine-battery" "$BATTERY is $state\n($status at $level%)" --icon="$ICONS/battery/$icon" --replace="$DUNST_ID";
     else
         dunstify --close="$DUNST_ID";
     fi

--- a/scripts/amtoine-hdmi
+++ b/scripts/amtoine-hdmi
@@ -103,7 +103,7 @@ notify_brightness () {
   #
   # TODO.
   #
-  dunstify "amtoine-hdmi" "Brightness ($1)\n$2" -h "int:value:$2" -u low --icon="$ICONS/video/brightness.png" --replace="$DUNST_ID"
+  dunstify "amtoine-hdmi" "Brightness ($1)\n$2" -h "int:value:$2" -u low --icon="$ICONS/video/sun.png" --replace="$DUNST_ID"
 }
 
 

--- a/scripts/amtoine-hdmi
+++ b/scripts/amtoine-hdmi
@@ -26,7 +26,7 @@ eval set -- "$OPTIONS"
 # the environment variables
 [ ! -v MAIN ] && MAIN="eDP-1"
 [ ! -v SECOND ] && SECOND="HDMI-2"
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [ -z "$DUNST_ID" ] && DUNST_ID=5
 
 

--- a/scripts/amtoine-mocp
+++ b/scripts/amtoine-mocp
@@ -21,7 +21,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # environment variables.
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [[ ! -v DUNST_ID ]] && DUNST_ID=3
 [[ ! -v FOLLOW_SLEEP ]] && FOLLOW_SLEEP=1
 [[ ! -v FOLLOW_LOOPS ]] && FOLLOW_LOOPS=10

--- a/scripts/amtoine-pcm
+++ b/scripts/amtoine-pcm
@@ -22,7 +22,7 @@ eval set -- "$OPTIONS"
 # environment variables
 [[ ! -v DUNST_ID ]] && DUNST_ID=6
 [[ ! -v PICOM_EXTRA_FLAGS ]] && PICOM_EXTRA_FLAGS="--experimental-backends"
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 
 
 usage () {

--- a/scripts/amtoine-pcm
+++ b/scripts/amtoine-pcm
@@ -81,10 +81,10 @@ main () {
       if pgrep -x "picom" > /dev/null
       then
         killall picom
-        [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-pcm" "picom killed" --icon="$ICONS/video/compositor-off.png" --replace "$DUNST_ID"
+        [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-pcm" "picom killed" --icon="$ICONS/video/compositor/off.png" --replace "$DUNST_ID"
       else
         picom  --daemon $PICOM_EXTRA_FLAGS
-        [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-pcm" "picom started" --icon="$ICONS/video/compositor-off.png" --replace "$DUNST_ID"
+        [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-pcm" "picom started" --icon="$ICONS/video/compositor/on.png" --replace "$DUNST_ID"
       fi;;
     blur )
       if grep "^#blur-method" ~/.config/picom/picom.conf > /dev/null

--- a/scripts/amtoine-scrot
+++ b/scripts/amtoine-scrot
@@ -23,7 +23,7 @@ eval set -- "$OPTIONS"
 # the environment variables
 [[ ! -v SCREENSHOT_PATH ]] && SCREENSHOT_PATH="$HOME/images/scrot"
 [[ ! -v FORMAT ]] && FORMAT='%Y-%m-%d_%H-%M-%S_$wx$h'
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 
 usage () {
   #

--- a/scripts/amtoine-sound
+++ b/scripts/amtoine-sound
@@ -65,7 +65,7 @@ notify () {
   # TODO.
   #
   _volume=$(amixer sget "$1" | grep 'Right:' | awk -F'[][]' '{ print $2 }' | sed 's/%//')
-  dunstify "volume on $1" "$_volume %" -h "int:value:$_volume" -u low --icon="$ICONS/audio/volume.png" --replace "$DUNST_ID"
+  dunstify "volume on $1" "$_volume %" -h "int:value:$_volume" -u low --icon="$ICONS/audio/audio-wave.png" --replace "$DUNST_ID"
 }
 
 
@@ -75,7 +75,7 @@ mute_notify () {
   #
   if amixer sget "$1" | grep "\[on\]" > /dev/null; then
     _volume=$(amixer sget "$1" | grep 'Right:' | awk -F'[][]' '{ print $2 }' | sed 's/%//')
-    dunstify -u low "$1" "Device unmuted\n$_volume %" -h "int:value:$_volume"  --icon="$ICONS/audio/unmute.png" --replace "$DUNST_ID"
+    dunstify -u low "$1" "Device unmuted\n$_volume %" -h "int:value:$_volume"  --icon="$ICONS/audio/voice.png" --replace "$DUNST_ID"
   else
     dunstify -u low "$1" "Device muted"  --icon="$ICONS/audio/mute.png" --replace "$DUNST_ID"
   fi
@@ -88,9 +88,9 @@ bluetooth_notify () {
   #
   if pacmd list-cards | grep -B5 "$DEVICE" | grep 'active profile'
   then
-    dunstify "Bluetooth" "$DEVICE active"  --icon="$ICONS/bluetooth/active.png"
+    dunstify "Bluetooth" "$DEVICE active"  --icon="$ICONS/bluetooth/bluetooth-connected.png"
   else
-    dunstify "Bluetooth" "$DEVICE disabled"  --icon="$ICONS/bluetooth/disabled.png"
+    dunstify "Bluetooth" "$DEVICE disabled"  --icon="$ICONS/bluetooth/bluetooth.png"
   fi
 }
 

--- a/scripts/amtoine-sound
+++ b/scripts/amtoine-sound
@@ -24,7 +24,7 @@ eval set -- "$OPTIONS"
 [[ ! -v DEVICE ]] && DEVICE="JBL Xtreme"
 [[ ! -v ON ]] && ON="a2dp_sink"
 [[ ! -v OFF ]] && OFF="off"
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [ -z "$DUNST_ID" ] && DUNST_ID=2
 
 

--- a/scripts/amtoine-sys-stats
+++ b/scripts/amtoine-sys-stats
@@ -20,7 +20,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # allow the user to change the environment variables.
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 
 
 usage () {

--- a/scripts/amtoine-sys-stats
+++ b/scripts/amtoine-sys-stats
@@ -64,14 +64,14 @@ main () {
     esac
   done
 
-  dunstify "amtoine-sys-stats" "polling the system for information..." --icon="$ICONS/misc/gears.png"
+  dunstify "amtoine-sys-stats" "polling the system for information..." --icon="$ICONS/misc/iphone-spinner.png"
 
   memory=$(free -m | awk 'NR==2{printf "%s/%sMB (%.2f%%)\n", $3,$2,$3*100/$2 }')
   load=$(top -bn1 | grep load | awk '{printf "%.2f\n", $(NF-2)}')
   cpu_temp=$(sensors | grep 'Core .:' | awk -F' ' '{ print $3 }')
 
   dunstify "Usage" "$memory" --icon="$ICONS/misc/usage-chart.png"
-  dunstify "Load" "$load" --icon="$ICONS/misc/brain-machine.png"
+  dunstify "Load" "$load" --icon="$ICONS/misc/processor.png"
   dunstify "CPU" "$cpu_temp" --icon="$ICONS/misc/temperature.png"
 }
 

--- a/scripts/amtoine-time-date
+++ b/scripts/amtoine-time-date
@@ -63,7 +63,7 @@ main () {
     esac
   done
 
-  notify-send -t 3500 "$(date '+%a %b %e%n%r')" --icon="$ICONS/misc/calendar.png"
+  notify-send -t 3500 "$(date '+%a %b %e%n%r')" --icon="$ICONS/misc/planner.png"
 }
 
 

--- a/scripts/amtoine-time-date
+++ b/scripts/amtoine-time-date
@@ -19,7 +19,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # allow the user to change the environment variables.
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 
 
 usage () {

--- a/scripts/amtoine-update
+++ b/scripts/amtoine-update
@@ -27,21 +27,21 @@ eval set -- "$OPTIONS"
 
 check_updates () {
   # Check the system for updates.
-  dunstify "amtoine-update" "pulling updates..."
+  dunstify "amtoine-update" "pulling updates..." --icon="$ICONS/notification/notification.png"
   updates=$(checkupdates | wc -l)
   if [ "$updates" -eq "0" ]; then
-    dunstify "amtoine-update" "everything is up to date!" --icon="$ICONS/misc/ok.png"
+    dunstify "amtoine-update" "everything is up to date!" --icon="$ICONS/misc/empty-treasure-chest.png"
   else
-    dunstify "amtoine-update" "there are $updates updates." --icon="$ICONS/misc/package.png"
+    dunstify "amtoine-update" "there are $updates updates." --icon="$ICONS/misc/treasure-chest.png"
   fi
 }
 
 
 update () {
   # Update the system with pacman in a popup terminal.
-  dunstify "amtoine-update" "please confirm your password in the popup window" --icon="$ICONS/lock/locked.png"
+  dunstify "amtoine-update" "please confirm your password in the popup window" --icon="$ICONS/lock/lock.png"
   $TERMINAL sudo pacman -Syyu
-  dunstify "amtoine-update" "update did complete successfully" --icon="$ICONS/lock/unlocked.png"
+  dunstify "amtoine-update" "update did complete successfully" --icon="$ICONS/lock/padlock.png"
   check_updates
 }
 

--- a/scripts/amtoine-update
+++ b/scripts/amtoine-update
@@ -21,7 +21,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # environment variables
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [[ ! -v TERMINAL ]] && TERMINAL="st -e"
 
 

--- a/scripts/amtoine-weather-get
+++ b/scripts/amtoine-weather-get
@@ -66,7 +66,7 @@ main () {
     esac
   done
 
-  notify-send -t 4500 "$(curl -s "wttr.in/{$PLACES}?format=3")" --icon="$ICONS/misc/weather-cloud-and-sun.png"
+  notify-send -t 4500 "$(curl -s "wttr.in/{$PLACES}?format=3")" --icon="$ICONS/misc/partly-cloudy-day.png"
 }
 
 

--- a/scripts/amtoine-weather-get
+++ b/scripts/amtoine-weather-get
@@ -20,7 +20,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # allow the user to change the environment variables.
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 [[ ! -v PLACES ]] && PLACES="Paris,Seoul,Nantes"
 
 

--- a/scripts/amtoine-xal
+++ b/scripts/amtoine-xal
@@ -72,8 +72,8 @@ main () {
   done
   [ -z "$ACTION" ] && usage
   case "$ACTION" in
-    disable ) xautolock -disable; [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-xal" "xautolock disabled" --icon="$ICONS/lock/unlocked.png" ;;
-    enable) xautolock -enable; [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-xal" "xautolock enabled" --icon="$ICONS/lock/locked.png" ;;
+    disable ) xautolock -disable; [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-xal" "xautolock disabled" --icon="$ICONS/lock/padlock.png" ;;
+    enable) xautolock -enable; [[ "$NOTIFY" == "yes" ]] && dunstify "amtoine-xal" "xautolock enabled" --icon="$ICONS/lock/lock.png" ;;
     * ) echo "an error occured (got unexpected '$ACTION')" ;;
   esac
 }

--- a/scripts/amtoine-xal
+++ b/scripts/amtoine-xal
@@ -20,7 +20,7 @@ if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
 
 # environment variables
-[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/dark/128x128"
+[[ ! -v ICONS ]] && ICONS="/usr/share/icons/amtoine-icons-git/stickers/100x100"
 
 
 usage () {


### PR DESCRIPTION
This PR adapts the scripts, especially the name of the icons and the default icon theme path, to the new icons package of mine, amtoine-icons-git.

Below is the list of all scripts requiring some icons:
- [x] amtoine-battery
- [x] amtoine-hdmi
- [x] amtoine-pcm
- [ ] amtoine-mocp
- [ ] amtoine-scrot
- [x] amtoine-sys-stats
- [x] amtoine-time-date
- [x] amtoine-weather-get
- [x] amtoine-xal
- [x] amtoine-update
- [x] amtoine-sound
