### PR TITLE
gh-notify: add the --silent switch

### DIFF
--- a/scripts/amtoine-gh-notify
+++ b/scripts/amtoine-gh-notify
@@ -2,13 +2,13 @@
 
 # environment variables.
 [ -z "$DUNST_ID" ] && DUNST_ID=8
-DUNST_HEADER="amtoine-gh-api"
+DUNST_HEADER="amtoine-gh-notify"
 
 
 # create the temporary file to hold the result of the API pull.
 tmpdir="/tmp/amtoine-scripts-git"
 mkdir -p "$tmpdir"
-tmpfile=$(mktemp "$tmpdir/gh-api.XXXXXX")
+tmpfile=$(mktemp "$tmpdir/gh-notify.XXXXXX")
 trap  'rm "$tmpfile"' 0 1 15
 
 

--- a/scripts/amtoine-gh-notify
+++ b/scripts/amtoine-gh-notify
@@ -32,6 +32,27 @@ get_users  () { get_from_json '.[].repository.owner.login'; }
 get_issues () { get_from_json '.[].subject.url' | sed 's|.*/||g'; }
 
 
+help () {
+  #
+  # the help function.
+  #
+  echo "amtoine-gh-notify:"
+  echo "     This script allows the user to pull notifications from GitHub."
+  echo "     Do not forget to puth it in your PATH."
+  echo ""
+  echo "Usage:"
+  echo "     amtoine-gh-notify [-hs]"
+  echo ""
+  echo "Switches:"
+  echo "     -h/--help               shows this help."
+  echo "     -s/--silent             pull the GitHub API silently and notify only when there are notifications."
+  echo ""
+  echo "Environment variables:"
+  echo "     DUNST_ID                the id of the sound notification, to replace them properly (defaults to 8)"
+  exit 0
+}
+
+
 main () {
     while [[ $# -gt 0 ]]; do
         case "$1" in

--- a/scripts/amtoine-gh-notify
+++ b/scripts/amtoine-gh-notify
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# parse the arguments.
+OPTIONS=$(getopt -o sh --long silent,help -n 'amtoine-gh-notify' -- "$@")
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$OPTIONS"
+
 # environment variables.
 [ -z "$DUNST_ID" ] && DUNST_ID=8
 DUNST_HEADER="amtoine-gh-notify"
@@ -13,9 +18,9 @@ trap  'rm "$tmpfile"' 0 1 15
 
 
 pull_from_api () {
-    dunstify "$DUNST_HEADER" "pulling information from the API..." --replace "$DUNST_ID"
+    [ -z "$1" ] && dunstify "$DUNST_HEADER" "pulling information from the API..." --replace "$DUNST_ID"
     gh api notifications --jq '.' | tee "$tmpfile" > /dev/null
-    dunstify "$DUNST_HEADER" "pulling information from the API... done!" --replace "$DUNST_ID"
+    [ -z "$1" ] && dunstify "$DUNST_HEADER" "pulling information from the API... done!" --replace "$DUNST_ID"
 }
 
 
@@ -28,10 +33,19 @@ get_issues () { get_from_json '.[].subject.url' | sed 's|.*/||g'; }
 
 
 main () {
-    pull_from_api
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help )  help ;;
+            -s | --silent) SILENT="yes"; shift 1;;
+            -- ) shift; break ;;
+            * ) break ;;
+        esac
+    done
+
+    pull_from_api "$SILENT"
     if [ "$(get_nb_notifications)" -eq 0 ];
     then
-        dunstify "$DUNST_HEADER" "no notifications for now..." --urgency low
+        [ -z "$SILENT" ] && dunstify "$DUNST_HEADER" "no notifications for now..." --urgency low
     else
         readarray -t titles < <(get_titles)
         readarray -t repos < <(get_repos)


### PR DESCRIPTION
This PR adds a flag system to `amtoine-gh-notify` and mostly the `--silent` switch to throw notifications on the desktop only when there are notifications on GitHub.