### PR TITLE
amtoine-update: add the --silent switch

### DIFF
--- a/scripts/amtoine-update
+++ b/scripts/amtoine-update
@@ -15,7 +15,7 @@
 # Contributors: Stevan Antoine
 
 # parse the arguments
-OPTIONS=$(getopt -o hcu --long help,check,update \
+OPTIONS=$(getopt -o hcus --long help,check,update,silent \
               -n 'amtoine-update' -- "$@")
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 eval set -- "$OPTIONS"
@@ -27,10 +27,10 @@ eval set -- "$OPTIONS"
 
 check_updates () {
   # Check the system for updates.
-  dunstify "amtoine-update" "pulling updates..." --icon="$ICONS/notification/notification.png"
+  [ -z "$1" ] && dunstify "amtoine-update" "pulling updates..." --icon="$ICONS/notification/notification.png"
   updates=$(checkupdates | wc -l)
   if [ "$updates" -eq "0" ]; then
-    dunstify "amtoine-update" "everything is up to date!" --icon="$ICONS/misc/empty-treasure-chest.png"
+    [ -z "$1" ] && dunstify "amtoine-update" "everything is up to date!" --icon="$ICONS/misc/empty-treasure-chest.png"
   else
     dunstify "amtoine-update" "there are $updates updates." --icon="$ICONS/misc/treasure-chest.png"
   fi
@@ -50,7 +50,7 @@ usage () {
   #
   # the usage function.
   #
-  echo "Usage: amtoine-update [-hcu]"
+  echo "Usage: amtoine-update [-hcus]"
   echo "Type -h or --help for the full help."
   exit 0
 }
@@ -63,12 +63,13 @@ help () {
   echo "     a tool to check and update the system."
   echo ""
   echo "Usage:"
-  echo "     amtoine-update [-hcu]"
+  echo "     amtoine-update [-hcus]"
   echo ""
   echo "Switches:"
   echo "     -h/--help             shows this help."
   echo "     -c/--check            check for system updates."
   echo "     -u/--update           update the system."
+  echo "     -s/--silent           pull the Arch repositories silently and notify only when there are updates."
   echo ""
   echo "Environment variables:"
   echo "     ICONS                   the path the the icons (defaults to '/usr/share/icons/amtoine-icons-git/dark/128x128')"
@@ -84,6 +85,7 @@ main () {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h | --help )    help ;;
+      -s | --silent )  SILENT="yes"; shift 1 ;;
       -c | --check )   ACTION="check"; shift 1 ;;
       -u | --update )  ACTION="update"; shift 1 ;;
       -- ) shift; break ;;
@@ -94,7 +96,7 @@ main () {
   # an action is required
   [ -z "$ACTION" ] && usage
   case "$ACTION" in
-    check ) check_updates ;;
+    check ) check_updates "$SILENT" ;;
     update ) update ;;
     * ) echo "an error occured (got unexpected '$ACTION')"; exit 1 ;;
   esac


### PR DESCRIPTION
This PR adds the `--silent` switch to `amtoine-update` to pull updates silently and notify only when updates are available.