### PR TITLE
add the amtoine-syssync script

### DIFF
--- a/examples/amtoine-syssync/default-config.txt
+++ b/examples/amtoine-syssync/default-config.txt
@@ -1,0 +1,4 @@
+etc/default/grub
+etc/pacman.conf
+etc/sddm.conf
+usr/share/sddm/themes/sugar-candy/theme.conf

--- a/scripts/amtoine-syssync
+++ b/scripts/amtoine-syssync
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+from_directory="$HOME/.local"
+
+files=(
+etc/default/grub
+etc/pacman.conf
+etc/sddm.conf
+usr/share/sddm/themes/sugar-candy/theme.conf
+)
+
+
+sync_files () {
+    for file in "${files[@]}";
+    do
+        sudo cp "$from_directory/$file" "/$file" --verbose
+    done
+}
+
+
+run_post_sync_commands () {
+    sudo grub-mkconfig -o /boot/grub/grub.cfg
+}
+
+
+sync_files
+run_post_sync_commands

--- a/scripts/amtoine-syssync
+++ b/scripts/amtoine-syssync
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-from_directory="$HOME/.local"
+# parse the arguments.
+OPTIONS=$(getopt -o ph --long post,help -n 'amtoine-syssync' -- "$@")
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+eval set -- "$OPTIONS"
 
-files=(
-etc/default/grub
-etc/pacman.conf
-etc/sddm.conf
-usr/share/sddm/themes/sugar-candy/theme.conf
-)
+# the environment variables
+[ -z "$SYSTEM" ] && SYSTEM="$HOME/.local"
+[ -z "$CONFIG" ] && CONFIG="$XDG_CONFIG_HOME/amtoine-syssync/config.txt"
 
 
 sync_files () {
-    for file in "${files[@]}";
+    for file in $(cat "$CONFIG")
     do
-        sudo cp "$from_directory/$file" "/$file" --verbose
+        sudo cp "$SYSTEM/$file" "/$file" --verbose
     done
 }
 
@@ -23,5 +23,62 @@ run_post_sync_commands () {
 }
 
 
-sync_files
-run_post_sync_commands
+usage () {
+  #
+  # the usage function.
+  #
+  echo "Usage: amtoine-syssync [-hp]"
+  echo "Type -h or --help for the full help."
+  exit 0
+}
+
+
+help () {
+  #
+  # the help function.
+  #
+  echo "amtoine-syssync:"
+  echo "     This script allows the user to easily manage syssync devices."
+  echo "     Do not forget to puth it in your PATH."
+  echo ""
+  echo "Usage:"
+  echo "     amtoine-syssync [-hp]"
+  echo ""
+  echo "Switches:"
+  echo "     -h/--help               shows this help."
+  echo "     -p/--post               runs post sync commands, such as \`grub-mkconfig\`, ..."
+  echo ""
+  echo "Environment variables:"
+  echo "     SYSTEM                  the path where the system config files are stored (defaults to \`\$HOME/.local\`)"
+  echo "     CONFIG                  the path to the config file (defaults to \`\$XDG_CONFIG_HOME/amtoine-syssync/config.txt\`)"
+  exit 0
+}
+
+
+main () {
+  #
+  # TODO.
+  #
+  POST=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h | --help ) help ;;
+      -p | --post ) POST="true"; shift 1;;
+      -- ) shift; break ;;
+      * ) break ;;
+    esac
+  done
+
+  [ ! -f "$CONFIG" ] && {
+    echo "'$CONFIG' does not exist..."
+    echo -n "Please have a look at the default config file at "
+    echo "/usr/local/share/amtoine-scripts/examples/."
+    exit 1
+  }
+
+  sync_files
+  [ -n "$POST" ] && run_post_sync_commands
+}
+
+
+main "$@"


### PR DESCRIPTION
This PR adds a new script to synchronize system configuration files, from a local/user collection of config files, and runs post sync commands, such as `grub-mkconfig` to apply the changes to the system.