### PR TITLE
FEATURE: track "explicit" and "all" pacman packages

### DIFF
--- a/scripts/amtoine-upl
+++ b/scripts/amtoine-upl
@@ -71,7 +71,8 @@ main () {
   }
 
   echo "updating packages list..."
-    pacman -Qe > "$DIR/all.pacman"
+    pacman -Q > "$DIR/all.pacman"
+    pacman -Qe > "$DIR/explicit.pacman"
     pacman -Qen > "$DIR/native.pacman"
   echo "updating dependencies list..."
     comm -13 <(pacman -Qdt | sort) <(pacman -Qdtt | sort) > "$DIR/opt.pacman"


### PR DESCRIPTION
This PR tracks all `pacman` packages in `all.pacman` and explicitely installed ones in `explicit.pacman`.