### PR TITLE
FIX: allow amtoine-scrot to create all directories

### DIFF
--- a/scripts/amtoine-scrot
+++ b/scripts/amtoine-scrot
@@ -77,7 +77,10 @@ main () {
     esac
   done
 
-  [ ! -d "$SCREENSHOT_PATH" ] && { echo -e "'$SCREENSHOT_PATH' does not exist\nCreating it..."; mkdir "$SCREENSHOT_PATH"; }
+  [ ! -d "$SCREENSHOT_PATH" ] && {
+      echo -e "'$SCREENSHOT_PATH' does not exist\nCreating it...";
+      mkdir "$SCREENSHOT_PATH" -p;
+  }
 
 	case "$1" in
 	full)


### PR DESCRIPTION
This PR makes sure `amtoine-scrot` creates all the nested directories to the picture collection with `mkdir -p`.