### PR TITLE
use `stdx Option` in `tmux-sessionizer.nu`

### DIFF
--- a/nu_scripts/scripts/tmux-sessionizer.nu
+++ b/nu_scripts/scripts/tmux-sessionizer.nu
@@ -1,5 +1,6 @@
 #!/usr/bin/env nu
 use std log
+use stdx *
 
 # FIXME: complex type annotation, waiting for https://github.com/nushell/nushell/pull/9769
 # record<stdout: string, stderr: string, exit_code: int>
@@ -18,6 +19,7 @@ def list-sessions [--expand: bool] {
     if not $expand {
         return $sessions
     }
+
     # FIXME: complex type annotation, waiting for https://github.com/nushell/nushell/pull/9769
     # let pwds: table<name: string, pwd: path> = ...
     let pwds = ^tmux list-sessions -F '#{session_name}:#{pane_current_path}'
@@ -37,14 +39,15 @@ def list-sessions [--expand: bool] {
 }
 
 # FIXME: complex type annotation, waiting for https://github.com/nushell/nushell/pull/9769
-# table<name: string, attached: bool, windows: table<app: string>, pwd: path>
+# table<name: string, attached: bool, windows: table<app: string>, pwd: path> -> record<type: string, some: bool, data: string>
+# table<name: string, attached: bool, windows: table<app: string>, pwd: path> -> record<type: string, some: bool, data: list<string>>
 def pick-session-with-style [
     message: string,
     current_session: string,
     session_color: string,
     --multi: bool,
     --expand: bool = false
-]: [table -> string, table -> list<string>] {
+] {
     let named_sessions = $in | update name {|it| (
             (if $it.name == $current_session { ansi $session_color } else { ansi default })
             ++ (if $it.attached { "* " } else { "  " })
@@ -68,7 +71,7 @@ def pick-session-with-style [
     }
 
     if ($choices | is-empty) {
-        return
+        return (Option new null)
     }
 
     let choices = if $expand {
@@ -77,7 +80,14 @@ def pick-session-with-style [
         $choices
     }
 
-    $choices | ansi strip | split column " | " | get column1 | str trim --left --char '*' | str trim
+    Option new (
+        $choices
+            | ansi strip
+            | split column " | "
+            | get column1
+            | str trim --left --char '*'
+            | str trim
+    )
 }
 
 def switch-session [session?: string, --expand: bool = false] {
@@ -92,11 +102,12 @@ def switch-session [session?: string, --expand: bool = false] {
         let prompt = $"(ansi cyan)Choose a session to switch to(ansi reset)"
         let choice = $sessions
             | pick-session-with-style --expand $expand $prompt $current_session "yellow"
-        if ($choice | is-empty) {
-            return
+
+        if ($choice | Option is-none) {
+            return (Option new null)
         }
 
-        $choice
+        $choice | Option unwrap
     } else {
         let sessions = list-sessions | get name
 
@@ -134,11 +145,13 @@ def remove-sessions [--expand: bool = false] {
     let choices = $sessions
         | pick-session-with-style --expand $expand --multi $prompt $current_session "red"
 
-    if ($choices | is-empty) {
-        return
+    if ($choices | Option is-none) {
+        return (Option new null)
     }
 
-    $sessions | where name in $choices | sort-by attached | each {|session|
+    let sessions_to_remove = $choices | Option unwrap
+
+    $sessions | where name in $sessions_to_remove | sort-by attached | each {|session|
         log debug $"killing session '($session.name)'"
         if $session.attached {
             new-session


### PR DESCRIPTION
this is an experiment to try and use the [`Option` type](https://github.com/1Kinoti/stdx.nu) designed by @1Kinoti, in the `tmux-sessionizer.nu` script :smirk: 

first of all, i have to say i love this `stdx.nu` package, how the code feels with the changes and the rest, nice job @1Kinoti :clap: :clap: 

## installation
the `tmux-sessionizer.nu` script is installed in `~/.local/bin/`.

to install `stdx.nu`, simply issue the following command
```nushell
cp --recursive /path/to/stdx.nu/stdx ~/.local/bin/
```

and that's it :ok_hand: 

## :test_tube: performance
command: `std bench { tmux-sessionizer.nu <options> } --rounds 10 --verbose --pretty`

### on the tip of this PR branch:

--list: **337ms 397µs 434ns +/- 4ms 383µs 712ns**
--list --expand: **541ms 761µs 374ns +/- 3ms 94µs 824ns**

### on the current main branch
```nushell
> git checkout eaed8b2  # current main
> cp nu_scripts/scripts/* ~/.local/bin/ # reinstall the script
```

--list: **69ms 176µs 369ns +/- 1ms 325µs 968ns**
--list --expand: **159ms 680µs 557ns +/- 1ms 830µs 480ns**

:exclamation: this means that with `stdx Option`
- `tmux-sessionizer.nu --list` is slower by a factor between around 4.73 and 4.99
- `tmux-sessionizer.nu --list --expand` is slower by a factor between around 3.34 and 3.42